### PR TITLE
fix: make artisan command package:discover turn off for processors by default.

### DIFF
--- a/config/profiler.php
+++ b/config/profiler.php
@@ -95,6 +95,7 @@ return [
     'turn_off_processors_for_paths' => [
         'telescope',
         '_debugbar',
+        'package:discover',
     ],
 
     /*


### PR DESCRIPTION
This pull request will make artisan command `package:discover` bypass for the processors. 

Original config will make curl exception during the composer install if laravel-profiler is not started.

```
   GuzzleHttp\Exception\ConnectException  : cURL error 6: Could not resolve: profiler (Domain name not found) (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)

  at /Users/chris_lee/WorkZone/GitZone/GetokenCode/revolution/revolution-backend/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:185
    181|         );
    182|
    183|         // Create a connection exception if it was a specific error code.
    184|         $error = isset($connectionErrors[$easy->errno])
  > 185|             ? new ConnectException($message, $easy->request, null, $ctx)
    186|             : new RequestException($message, $easy->request, $easy->response, null, $ctx);
    187|
    188|         return \GuzzleHttp\Promise\rejection_for($error);
    189|     }

  Exception trace:

  1   GuzzleHttp\Handler\CurlFactory::createRejection(Object(GuzzleHttp\Handler\EasyHandle))
      /Users/chris_lee/WorkZone/GitZone/GetokenCode/revolution/revolution-backend/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:149

  2   GuzzleHttp\Handler\CurlFactory::finishError(Object(GuzzleHttp\Handler\CurlHandler), Object(GuzzleHttp\Handler\EasyHandle), Object(GuzzleHttp\Handler\CurlFactory))
      /Users/chris_lee/WorkZone/GitZone/GetokenCode/revolution/revolution-backend/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:102

  Please use the argument -v to see more details.
```